### PR TITLE
Symlinks real suite names to "default"

### DIFF
--- a/ansible_1.9
+++ b/ansible_1.9
@@ -1,0 +1,1 @@
+default

--- a/ansible_latest
+++ b/ansible_latest
@@ -1,0 +1,1 @@
+default


### PR DESCRIPTION
The two suite names for the inspec tests refer to different Ansible
versions to test, but the inspec tests themselves should be the same for
both versions of Ansible. Therefore let's use symlinks so that the
inspec runner finds "default" when it searches for:

  * ansible_latest
  * ansible_1.9

Voila.